### PR TITLE
Integrate with services in preparation for push to RubyGems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: ruby
+rvm:
+- 2.2.1
+script: bundle exec rspec
+addons:
+  code_climate:
+    repo_token: 781c439d68cbb928316deaec1c7136f98423e1db87238f99cbc95183de94df9e
+notifications:
+  email: false
+  hipchat:
+    rooms:
+      secure: pLL6WXsWnvigZNgcYYwr0el3AG3WbRXOV4zAoBx/pAD/y51/KOjWboUO5szOqIicdSBJTIY5el7wK4uUi5elseumjl1jvOQSG7izvCGzDekuJuOTj9f6MdLtigbIaWO5/NWtXw0/JGHDQJpB4HyOv1mGAjQ3Y6MKxMNv+RUsgRI=

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code Climate](https://codeclimate.com/github/panorama-ed/order_as_specified/badges/gpa.svg)](https://codeclimate.com/github/panorama-ed/order_as_specified) [![Test Coverage](https://codeclimate.com/github/panorama-ed/order_as_specified/badges/coverage.svg)](https://codeclimate.com/github/panorama-ed/order_as_specified) [![Build Status](https://travis-ci.org/panorama-ed/order_as_specified.svg)](https://travis-ci.org/panorama-ed/order_as_specified) [![Inline docs](http://inch-ci.org/github/panorama-ed/order_as_specified.png)](http://inch-ci.org/github/panorama-ed/order_as_specified) [![Gem Version](https://badge.fury.io/rb/order_as_specified.svg)](http://badge.fury.io/rb/order_as_specified)
+
 # OrderAsSpecified
 
 `OrderAsSpecified` adds the ability to query an `ActiveRecord` class for results
@@ -100,6 +102,10 @@ TestObject.order_as_specified(language: ["fr", "es"])
      #<TestObject id: 4, language: "en">
    ]>
 ```
+
+## Documentation
+
+We have documentation on [RubyDoc](http://www.rubydoc.info/github/panorama-ed/order_as_specified/master).
 
 ## Contributing
 

--- a/order_as_specified.gemspec
+++ b/order_as_specified.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", "~> 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"
   spec.add_development_dependency "overcommit", "~> 0.23"
   spec.add_development_dependency "rspec", "~> 3.2"
   spec.add_development_dependency "rspec-rails", "~> 3.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require "codeclimate-test-reporter"
+CodeClimate::TestReporter.start
+
 # Connect to an in-memory database for ActiveRecord tests.
 require "temping"
 ActiveRecord::Base.


### PR DESCRIPTION
As per the steps [here](https://panoramaed.atlassian.net/wiki/display/EP/Open-Sourcing+Instructions). I added the BadgeFury badge in advance of the push to RubyGems.

Once this merges (since the badges depend on master), I'll ensure that all badges are correct and all services work as expected.