### PR TITLE
Gemspec: Release activerecord dependency to support rails 5

### DIFF
--- a/order_as_specified.gemspec
+++ b/order_as_specified.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 4.0"
+  spec.add_dependency "activerecord", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"

--- a/order_as_specified.gemspec
+++ b/order_as_specified.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails", "~> 3.2"
   spec.add_development_dependency "rubocop", "~> 0.29"
   spec.add_development_dependency "temping", "~> 3.2"
+  spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
Hey @JacobEvelyn 

Released gem from constrained dependency. Now support Activerecord  >= 4.0 instead of limiting it to Rails 4.2

Please review and merge.

Thanks.