### PR TITLE
Bump to 1.0

### DIFF
--- a/lib/order_as_specified/version.rb
+++ b/lib/order_as_specified/version.rb
@@ -1,3 +1,3 @@
 module OrderAsSpecified
-  VERSION = "0.1.0"
+  VERSION = "1.0"
 end


### PR DESCRIPTION
I went with "1.0" instead of "1.0.0" simply out of personal preference—I don't think we really have enough work here to differentiate between "minor releases" and "patches." Happy to change though; I don't really care.