### PR TITLE
Sanitize SQL inputs to protect against SQL injection

### DIFF
--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -22,7 +22,8 @@ module OrderAsSpecified
     conditions = params[:values].map do |value|
       raise OrderAsSpecified::Error, "Cannot order by `nil`" if value.nil?
 
-      "#{table}.#{attribute}='#{value}'"
+      # Sanitize each value to reduce the risk of SQL injection.
+      "#{table}.#{attribute}=#{sanitize(value)}"
     end
 
     scope = order(conditions.map { |cond| "#{cond} DESC" }.join(", "))

--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -13,8 +13,8 @@ module OrderAsSpecified
     distinct_on = hash.delete(:distinct_on)
     params = extract_params(hash)
 
-    table = params[:table]
-    attribute = params[:attribute]
+    table = connection.quote_table_name(params[:table])
+    attribute = connection.quote_column_name(params[:attribute])
 
     # We have to explicitly quote for now because SQL sanitization for ORDER BY
     # queries isn't in less current versions of Rails.

--- a/spec/postgresql_spec.rb
+++ b/spec/postgresql_spec.rb
@@ -42,6 +42,17 @@ RSpec.describe "PostgreSQL" do
         record = TestClass.order_as_specified(distinct_on: true, field: [bad_value]).to_a.first
         expect(record).to_not respond_to(:hi)
       end
+
+      it "quotes column and table names" do
+        table = "association_test_classes"
+        quoted_table = AssociationTestClass.connection.quote_table_name(table)
+
+        column = "id"
+        quoted_column = AssociationTestClass.connection.quote_column_name(column)
+
+        sql = TestClass.order_as_specified(distinct_on: true, table => { column => ["foo"] }).to_sql
+        expect(sql).to include("DISTINCT ON (#{quoted_table}.#{quoted_column}")
+      end
     end
   end
 end

--- a/spec/postgresql_spec.rb
+++ b/spec/postgresql_spec.rb
@@ -28,5 +28,20 @@ RSpec.describe "PostgreSQL" do
     it "returns distinct objects" do
       expect(subject.length).to eq 3
     end
+
+    context "input safety" do
+      before(:each) { TestClass.create(field: "foo") }
+
+      it "sanitizes column values" do
+        # Attempt to inject code to add a 'hi' field to each record. If the SQL inputs
+        # are properly sanitized, the code will be ignored and the returned model
+        # instances will not respond to #hi. If not, the code will execute and
+        # each of the returned model instances will have a #hi method to access the
+        # new field.
+        bad_value = "foo') field, 'hi'::varchar AS hi FROM test_classes --"
+        record = TestClass.order_as_specified(distinct_on: true, field: [bad_value]).to_a.first
+        expect(record).to_not respond_to(:hi)
+      end
+    end
   end
 end

--- a/spec/shared/order_as_specified_examples.rb
+++ b/spec/shared/order_as_specified_examples.rb
@@ -115,5 +115,16 @@ RSpec.shared_examples ".order_as_specified" do
       records = TestClass.order_as_specified(field: [bad_value]).to_a
       expect(records.count).to eq(2)
     end
+
+    it "quotes column and table names" do
+      table = "association_test_classes"
+      quoted_table = AssociationTestClass.connection.quote_table_name(table)
+
+      column = "id"
+      quoted_column = AssociationTestClass.connection.quote_column_name(column)
+
+      sql = TestClass.order_as_specified(table => { column => ["foo"] }).to_sql
+      expect(sql).to include("ORDER BY #{quoted_table}.#{quoted_column}")
+    end
   end
 end


### PR DESCRIPTION
This is my attempt to address the SQL injection issue described here: https://github.com/panorama-ed/order_as_specified/issues/21.

My solution uses [ActiveRecord::Base.sanitize](http://www.rubydoc.info/docs/rails/4.0.0/ActiveRecord/Sanitization/ClassMethods#sanitize-instance_method) to sanitize inputs before they're added to the query. I also added code to quote the table and column names, to protect against potential issues that could arise from them being left unquoted.