### PR TITLE
Update gem dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
+# 1.2
+
+This release contains an important change: `order_as_specified` is no longer
+vulnerable to SQL injection attacks. Big thanks to
+[Anthony Mangano](https://github.com/wangteji) for finding and fixing this
+issue.
+
+In addition, this release corrects an error in the `.gemspec`—this gem relies on
+ActiveRecord >= 4.0.1, not 4.0.0.
+
+# 1.1
+
+This release contains several minor changes:
+
+- Tests now run against Ruby 2.2.5 and 2.3.1 and Rails 4.2 and 5.0.
+- A code change was made to fix a Rails 5 deprecation warning.
+
 # 1.0
 
-We've hit our first major release! This release contains **no** breaking changes. The changes:
+We've hit our first major release! This release contains **no** breaking
+changes. The changes:
 
 - Added `:distinct_on` option. [[#3](https://github.com/panorama-ed/order_as_specified/issues/3)]
 - Improved error message for `nil` arguments. [[#8](https://github.com/panorama-ed/order_as_specified/pull/8)]

--- a/lib/order_as_specified/version.rb
+++ b/lib/order_as_specified/version.rb
@@ -1,3 +1,3 @@
 module OrderAsSpecified
-  VERSION = "1.1"
+  VERSION = "1.2"
 end

--- a/order_as_specified.gemspec
+++ b/order_as_specified.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.0"
+  spec.add_dependency "activerecord", ">= 4.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4"


### PR DESCRIPTION
This commit updates the .gemspec dependency from
ActiveRecord >=4.0.0 to >=4.0.1, as explained in #22.
In addition, it updates the CHANGELOG and bumps the
gem version up to 1.2.