### PR TITLE
using sanitize_sql method

### DIFF
--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -23,7 +23,7 @@ module OrderAsSpecified
       raise OrderAsSpecified::Error, "Cannot order by `nil`" if value.nil?
 
       # Sanitize each value to reduce the risk of SQL injection.
-      "#{table}.#{attribute}=#{sanitize(value)}"
+      "#{table}.#{attribute}='#{sanitize_sql(value)}'"
     end
 
     scope = order(conditions.map { |cond| "#{cond} DESC" }.join(", "))


### PR DESCRIPTION
Fix https://github.com/panorama-ed/order_as_specified/issues/26

## Problem

> pry(main)) > ModelObject.all.order_as_specified(....)
NoMethodError: undefined method `sanitize' for #Class:0x007fbed55982d8
Did you mean? sanitize_sql

## Solve

- using `sanitize_sql`
