### PR TITLE
Sanitize SQL using `ActiveRecord::Base.connection.quote`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   matrix:
     - AR_VERSION="~> 4.2.0"
     - AR_VERSION="~> 5.0.0"
+    - AR_VERSION="~> 5.1.0"
 notifications:
   email: false
   hipchat:

--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -19,11 +19,12 @@ module OrderAsSpecified
     # We have to explicitly quote for now because SQL sanitization for ORDER BY
     # queries isn't in less current versions of Rails.
     # See: https://github.com/rails/rails/pull/13008
+    db_connection = ActiveRecord::Base.connection
     conditions = params[:values].map do |value|
       raise OrderAsSpecified::Error, "Cannot order by `nil`" if value.nil?
 
       # Sanitize each value to reduce the risk of SQL injection.
-      "#{table}.#{attribute}=#{sanitize(value)}"
+      "#{table}.#{attribute}=#{db_connection.quote(value)}"
     end
 
     scope = order(conditions.map { |cond| "#{cond} DESC" }.join(", "))

--- a/spec/config/test_setup_migration.rb
+++ b/spec/config/test_setup_migration.rb
@@ -1,6 +1,10 @@
-class TestSetupMigration < ActiveRecord::Migration[4.2]
+VersionedMigration = ActiveRecord::Migration.try(:[], 5.0) || ActiveRecord::Migration
+
+class TestSetupMigration < VersionedMigration
   def up
-    return if ActiveRecord::Base.connection.data_source_exists?(:test_classes)
+    db_connection = ActiveRecord::Base.connection
+    return if db_connection.try(:table_exists?,:test_classes) || # AR 4.2
+              db_connection.try(:data_source_exists?,:test_classes) # AR > 5.0
 
     create_table :test_classes do |t|
       t.string :field

--- a/spec/config/test_setup_migration.rb
+++ b/spec/config/test_setup_migration.rb
@@ -1,4 +1,4 @@
-class TestSetupMigration < ActiveRecord::Migration
+class TestSetupMigration < ActiveRecord::Migration[4.2]
   def up
     return if ActiveRecord::Base.connection.data_source_exists?(:test_classes)
 


### PR DESCRIPTION
![screen shot 2017-06-01 at 18 21 43](https://cloud.githubusercontent.com/assets/7713/26692088/5dbd848e-46f7-11e7-97ea-c64c702c3da3.png)

Our team's deploy to 5.1 is waiting on this, and I hate including my own forks if it can be avoided. Any chance of a version bump? :3 