### PR TITLE
Fix rubocop error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,9 +8,6 @@ AccessorMethodName:
 Alias:
   Enabled: false
 
-AllCops:
-  RunRailsCops: true
-
 AmbiguousOperator:
   Enabled: false
 
@@ -75,7 +72,7 @@ Delegate:
 DeprecatedClassMethods:
   Enabled: false
 
-DeprecatedHashMethods:
+Style/PreferredHashMethods:
   Enabled: false
 
 Documentation:
@@ -202,6 +199,9 @@ Proc:
 RaiseArgs:
   Enabled: false
 
+Rails:
+  Enabled: true
+
 RedundantReturn:
   AllowMultipleReturnValues: true
 
@@ -235,7 +235,7 @@ Style/MultilineBlockChain:
 VariableInterpolation:
   Enabled: false
 
-TrailingComma:
+Style/TrailingCommaInLiteral:
   Enabled: false
 
 TrivialAccessors:

--- a/lib/order_as_specified/version.rb
+++ b/lib/order_as_specified/version.rb
@@ -1,3 +1,3 @@
 module OrderAsSpecified
-  VERSION = "1.3"
+  VERSION = "1.3".freeze
 end

--- a/order_as_specified.gemspec
+++ b/order_as_specified.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "order_as_specified/version"

--- a/spec/config/test_setup_migration.rb
+++ b/spec/config/test_setup_migration.rb
@@ -3,8 +3,8 @@ VersionedMigration = ActiveRecord::Migration.try(:[], 5.0) || ActiveRecord::Migr
 class TestSetupMigration < VersionedMigration
   def up
     db_connection = ActiveRecord::Base.connection
-    return if db_connection.try(:table_exists?,:test_classes) || # AR 4.2
-              db_connection.try(:data_source_exists?,:test_classes) # AR > 5.0
+    return if db_connection.try(:table_exists?, :test_classes) || # AR 4.2
+              db_connection.try(:data_source_exists?, :test_classes) # AR > 5.0
 
     create_table :test_classes do |t|
       t.string :field

--- a/spec/postgresql_spec.rb
+++ b/spec/postgresql_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "PostgreSQL" do
     end
 
     let(:shuffled_objects) do
-      fields = 3.times.map { |i| "Field #{i}" } * 2
-      5.times.map { |i| TestClass.create(field: fields[i]) }.shuffle
+      fields = Array.new(3) { |i| "Field #{i}" } * 2
+      Array.new(5) { |i| TestClass.create(field: fields[i]) }.shuffle
     end
 
     it "returns distinct objects" do

--- a/spec/shared/order_as_specified_examples.rb
+++ b/spec/shared/order_as_specified_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples ".order_as_specified" do
   end
 
   let(:shuffled_objects) do
-    5.times.map { |i| TestClass.create(field: "Field #{i}") }.shuffle
+    Array.new(5) { |i| TestClass.create(field: "Field #{i}") }.shuffle
   end
   let(:shuffled_object_fields) { shuffled_objects.map(&:field) }
   let(:shuffled_object_ids) { shuffled_objects.map(&:id) }
@@ -50,7 +50,7 @@ RSpec.shared_examples ".order_as_specified" do
 
     context "when the order includes nil" do
       let(:shuffled_objects) do
-        5.times.map do |i|
+        Array.new(5) do |i|
           TestClass.create(field: (i == 0 ? nil : "Field #{i}"))
         end.shuffle
       end

--- a/spec/support/association_test_class.rb
+++ b/spec/support/association_test_class.rb
@@ -1,4 +1,4 @@
-class AssociationTestClass < ActiveRecord::Base
+class AssociationTestClass < ApplicationRecord
   extend OrderAsSpecified
 
   belongs_to :test_class

--- a/spec/support/test_class.rb
+++ b/spec/support/test_class.rb
@@ -1,4 +1,4 @@
-class TestClass < ActiveRecord::Base
+class TestClass < ApplicationRecord
   extend OrderAsSpecified
 
   has_one :association_test_class


### PR DESCRIPTION
Fix https://github.com/panorama-ed/order_as_specified/issues/30

I got following error.
So, I fixed lint and did `rubocop -a`

```
$ rubocop -a 
Error: The `Style/TrailingComma` cop no longer exists. Please use `Style/TrailingCommaInLiteral` and/or `Style/TrailingCommaInArguments` instead.
(obsolete configuration found in /Users/k-toda/dev/src/github.com/panorama-ed/order_as_specified/.rubocop.yml, please update it)
The `Style/DeprecatedHashMethods` cop has been renamed to `Style/PreferredHashMethods`.
(obsolete configuration found in /Users/k-toda/dev/src/github.com/panorama-ed/order_as_specified/.rubocop.yml, please update it)
obsolete parameter RunRailsCops (for AllCops) found in /Users/k-toda/dev/src/github.com/panorama-ed/order_as_specified/.rubocop.yml
Use the following configuration instead:
Rails:
  Enabled: true
```