### PR TITLE
Fix test coverage so Code Climate can report it correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - bundle exec rspec
+  # The order of these matters; RSpec must be last for Code Climate's
+  # code coverage after_script to work.
   - bundle exec rubocop
+  - bundle exec rspec
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 addons:


### PR DESCRIPTION
Compare the previous master build with [this branch build](https://travis-ci.org/panorama-ed/order_as_specified/jobs/378817667) and note that the latter has this in its output while the former has an error:

```
Coverage report generated for RSpec to /home/travis/build/panorama-ed/order_as_specified/coverage. 25 / 25 LOC (100.0%) covered.
```