### PR TITLE
Use "case when ... then ... else end" to improve the query performance

### DIFF
--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -13,6 +13,7 @@ module OrderAsSpecified
   def order_as_specified(hash)
     distinct_on = hash.delete(:distinct_on)
     params = extract_params(hash)
+    return all if params[:values].empty?
 
     table = connection.quote_table_name(params[:table])
     attribute = connection.quote_column_name(params[:attribute])

--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -28,11 +28,15 @@ module OrderAsSpecified
       "#{table}.#{attribute}=#{db_connection.quote(value)}"
     end
 
-    scope = order(Arel.sql(conditions.map { |cond| "#{cond} DESC" }.join(", ")))
+    when_queries = conditions.map.with_index do |cond, index|
+      "WHEN #{cond} THEN #{index}"
+    end
+    case_query = "CASE #{when_queries.join(' ')} ELSE #{conditions.size} END"
+    scope = order(Arel.sql("#{case_query} ASC"))
 
     if distinct_on
       scope = scope.select(
-        Arel.sql("DISTINCT ON (#{conditions.join(', ')}) #{table}.*")
+        Arel.sql("DISTINCT ON (#{case_query}) #{table}.*")
       )
     end
 

--- a/spec/postgresql_spec.rb
+++ b/spec/postgresql_spec.rb
@@ -62,7 +62,8 @@ RSpec.describe "PostgreSQL" do
           distinct_on: true,
           table => { column => ["foo"] }
         ).to_sql
-        expect(sql).to include("DISTINCT ON (#{quoted_table}.#{quoted_column}")
+        pattern = "DISTINCT ON (CASE WHEN #{quoted_table}.#{quoted_column}"
+        expect(sql).to include(pattern)
       end
     end
   end

--- a/spec/shared/order_as_specified_examples.rb
+++ b/spec/shared/order_as_specified_examples.rb
@@ -65,6 +65,22 @@ RSpec.shared_examples ".order_as_specified" do
     end
   end
 
+  context "when the order is empty array" do
+    subject { TestClass.order_as_specified(field: []) }
+
+    let(:test_objects) do
+      Array.new(5) do |i|
+        TestClass.create(field: "Field #{i}")
+      end
+    end
+
+    it "keep the original order" do
+      test_objects # Build test objects
+      expect(subject.map(&:id)).
+        to eq test_objects.map(&:id)
+    end
+  end
+
   context "with another table name specified" do
     subject do
       TestClass.

--- a/spec/shared/order_as_specified_examples.rb
+++ b/spec/shared/order_as_specified_examples.rb
@@ -129,7 +129,8 @@ RSpec.shared_examples ".order_as_specified" do
       quoted_column = AssociationTestClass.connection.quote_column_name(column)
 
       sql = TestClass.order_as_specified(table => { column => ["foo"] }).to_sql
-      expect(sql).to include("ORDER BY #{quoted_table}.#{quoted_column}")
+      pattern = "ORDER BY CASE WHEN #{quoted_table}.#{quoted_column}"
+      expect(sql).to include(pattern)
     end
   end
 end


### PR DESCRIPTION
If we use
``` sql
ORDER BY
    (CASE 
        WHEN "table"."col" = value1 THEN 0 
        WHEN "table"."col" = value2 THEN 1 
    END) ASC
```
instead of the current version,
```sql
ORDER BY
    "table"."col" = value DESC,
    "table"."col" = value2 DESC
```
then the query performance will be much faster.

Here is a benchmark on the SQL Fiddle with 100 records.
The current version (http://sqlfiddle.com/#!17/7d007/5) took 8.4ms.
![image](https://user-images.githubusercontent.com/6697273/45146573-bfeec400-b1f5-11e8-99c1-cbcd792594b6.png)

The new version (http://sqlfiddle.com/#!17/7d007/4) only took 0.6ms.
![image](https://user-images.githubusercontent.com/6697273/45146621-d72db180-b1f5-11e8-9bbe-90b3038281a9.png)

The new version is 14x fater than the current version in this simple benchmark.


