### PR TITLE
Allow ordering by ranges

### DIFF
--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -53,7 +53,9 @@ module OrderAsSpecified
   # @param hash [Hash] the ActiveRecord-style arguments, such as:
   #   { other_objects: { id: [1, 5, 3] } }
   def extract_params(hash, table = table_name)
-    raise OrderAsSpecified::Error, "Could not parse params" unless hash.size == 1
+    unless hash.size == 1
+      raise OrderAsSpecified::Error, "Could not parse params"
+    end
 
     key, val = hash.first
 
@@ -69,7 +71,9 @@ module OrderAsSpecified
   end
 
   def range_clause(col, range)
-    raise OrderAsSpecified::Error, "Range needs to be increasing" if range.first >= range.last
+    if range.first >= range.last
+      raise OrderAsSpecified::Error, "Range needs to be increasing"
+    end
 
     op = range.exclude_end? ? "<" : "<="
     "#{col} >= #{quote(range.first)} AND #{col} #{op} #{quote(range.last)}"

--- a/spec/config/test_setup_migration.rb
+++ b/spec/config/test_setup_migration.rb
@@ -9,6 +9,7 @@ class TestSetupMigration < VersionedMigration
 
     create_table :test_classes do |t|
       t.string :field
+      t.integer :number_field
     end
 
     create_table :association_test_classes do |t|

--- a/spec/config/test_setup_migration.rb
+++ b/spec/config/test_setup_migration.rb
@@ -9,7 +9,7 @@ class TestSetupMigration < VersionedMigration
 
     create_table :test_classes do |t|
       t.string :field
-      t.integer :number_field
+      t.float :number_field
     end
 
     create_table :association_test_classes do |t|

--- a/spec/shared/order_as_specified_examples.rb
+++ b/spec/shared/order_as_specified_examples.rb
@@ -81,6 +81,25 @@ RSpec.shared_examples ".order_as_specified" do
     end
   end
 
+  context "when the order is a range" do
+    subject { TestClass.order_as_specified(number_field: [(3..4), (0..2)]) }
+
+    let(:test_objects) do
+      Array.new(5) do |i|
+        TestClass.create(number_field: i)
+      end
+    end
+
+    it "sorts according to range" do
+      test_objects # Build test objects
+
+      expect(subject.map(&:id)).to eq [
+        *test_objects.drop(3).map(&:id),
+        *test_objects.take(3).map(&:id)
+      ]
+    end
+  end
+
   context "with another table name specified" do
     subject do
       TestClass.

--- a/spec/shared/order_as_specified_examples.rb
+++ b/spec/shared/order_as_specified_examples.rb
@@ -82,7 +82,9 @@ RSpec.shared_examples ".order_as_specified" do
   end
 
   context "when the order is a range" do
-    subject { TestClass.order_as_specified(number_field: ranges).order(:number_field) }
+    subject do
+      TestClass.order_as_specified(number_field: ranges).order(:number_field)
+    end
 
     let(:ranges) { [(3..4), (0..2)] }
     let(:numbers) { [0, 1, 2, 3, 4] }
@@ -103,7 +105,7 @@ RSpec.shared_examples ".order_as_specified" do
     context "exclusive ranges" do
       let(:numbers) { [0, 1, 2, 3, 4, 0.9, 1.5] }
 
-      let(:ranges) { [(1...2), (0...1), (2...5)]}
+      let(:ranges) { [(1...2), (0...1), (2...5)] }
 
       it "sorts according to range" do
         expect(subject.map(&:number_field)).to eq [
@@ -193,6 +195,14 @@ RSpec.shared_examples ".order_as_specified" do
       sql = TestClass.order_as_specified(table => { column => ["foo"] }).to_sql
       pattern = "ORDER BY CASE WHEN #{quoted_table}.#{quoted_column}"
       expect(sql).to include(pattern)
+    end
+  end
+
+  context "invalid hash input" do
+    subject { TestClass.order_as_specified({}) }
+
+    it "raises an error" do
+      expect { subject }.to raise_error(OrderAsSpecified::Error)
     end
   end
 end


### PR DESCRIPTION
Example:

```
TestObject.order_as_specified(number_column: [(1..5), (6..10)])
```

Real-life usecase: We have a taxonomy of items set up, each category
being an id range. Subcategories take up a subsection of their parent
categories id range.

Sorting by ranges allows us to show items in multi-category searches in
an easy way.