### PR TITLE
Add MySQL tests, remove Code Climate, and fix Travis setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,40 @@
 language: ruby
 rvm:
-- 2.2.5
-- 2.5.1
+- 2.6
+- 2.5
+- 2.4
+# We test up to the latest version of Ruby here, and test these Ruby versions
+# against all support ActiveRecord versions. One test will be "duplicated"
+# below when we calculate code coverage, but I don't know how to avoid that and
+# still test all combinations of Ruby and ActiveRecord.
 before_script:
-  - psql -c 'create database order_as_specified_test;' -U postgres
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+- psql -c 'create database order_as_specified_test;' -U postgres
+- mysql -e 'CREATE DATABASE order_as_specified_test;'
 script:
-  - bundle exec rspec
-  - bundle exec rubocop
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-addons:
-  postgresql: "9.3"
+- bundle exec rspec
+services:
+- mysql
+- postgresql
 env:
-  global:
-    CC_TEST_REPORTER_ID=781c439d68cbb928316deaec1c7136f98423e1db87238f99cbc95183de94df9e
   matrix:
-    - AR_VERSION="~> 5.0.0"
-    - AR_VERSION="~> 5.1.0"
+  - AR_VERSION="~> 5.2.0"
+  - AR_VERSION="~> 5.1.0"
+  - AR_VERSION="~> 5.0.0"
+matrix:
+  include:
+  - rvm: 2.6
+    script:
+    - bundle exec rspec
+    - gem install --no-document rubocop rubocop-rspec-focused && rubocop
+    after_script:
+    - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+    env:
+    - CODE_COVERAGE=true
     - AR_VERSION="~> 5.2.0"
+branches:
+  only:
+  - master
 notifications:
   email: false
-  hipchat:
-    rooms:
-      secure: pLL6WXsWnvigZNgcYYwr0el3AG3WbRXOV4zAoBx/pAD/y51/KOjWboUO5szOqIicdSBJTIY5el7wK4uUi5elseumjl1jvOQSG7izvCGzDekuJuOTj9f6MdLtigbIaWO5/NWtXw0/JGHDQJpB4HyOv1mGAjQ3Y6MKxMNv+RUsgRI=
+  slack:
+    secure: lVaScxPymqeYlTh+KlprWDK+O18BkQTyNSBTfzsLFzWF3Dy+p1rp2aeh0AhuLVYQDrlmFZ7cDMZ1ZYDyV2Y6lLtt+4ii7rATagI8R9WUVYb90C97tu1M6v5tpIjoTEOLx9hGc66heyvq1hNCKXbTqsqmrD69FYdjuXnOfrIs6J4=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased (`master`)
+
+- We are dropping official support for Ruby 2.3 and below, though they may
+  continue to work.
+
 # 1.5
 
 This release improves performance by switching to use `CASE` statements. Huge

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Code Climate](https://codeclimate.com/github/panorama-ed/order_as_specified/badges/gpa.svg)](https://codeclimate.com/github/panorama-ed/order_as_specified) [![Test Coverage](https://codeclimate.com/github/panorama-ed/order_as_specified/badges/coverage.svg)](https://codeclimate.com/github/panorama-ed/order_as_specified) [![Build Status](https://travis-ci.org/panorama-ed/order_as_specified.svg)](https://travis-ci.org/panorama-ed/order_as_specified) [![Inline docs](http://inch-ci.org/github/panorama-ed/order_as_specified.png)](http://inch-ci.org/github/panorama-ed/order_as_specified) [![Gem Version](https://badge.fury.io/rb/order_as_specified.svg)](http://badge.fury.io/rb/order_as_specified)
+[![Code Coverage](https://codecov.io/gh/panorama-ed/order_as_specified/branch/master/graph/badge.svg)](https://codecov.io/gh/panorama-ed/order_as_specified)
+[![Build Status](https://travis-ci.com/panorama-ed/order_as_specified.svg)](https://travis-ci.com/panorama-ed/order_as_specified)
+[![Inline docs](http://inch-ci.org/github/panorama-ed/order_as_specified.png)](http://inch-ci.org/github/panorama-ed/order_as_specified)
+[![Gem Version](https://badge.fury.io/rb/order_as_specified.svg)](http://badge.fury.io/rb/order_as_specified)
 
 # OrderAsSpecified
 

--- a/order_as_specified.gemspec
+++ b/order_as_specified.gemspec
@@ -23,11 +23,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activerecord", ">= 5.0.0"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "codecov"
+  spec.add_development_dependency "mysql2"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-rails"
-  spec.add_development_dependency "rubocop"
-  spec.add_development_dependency "rubocop-rspec-focused"
-  spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.13"
 end

--- a/spec/config/database.yml
+++ b/spec/config/database.yml
@@ -7,3 +7,9 @@ postgresql_test:
   adapter: postgresql
   database: order_as_specified_test
   username: postgres
+
+mysql_test:
+  adapter: mysql2
+  database: order_as_specified_test
+  username: travis
+  encoding: utf8

--- a/spec/mysql_spec.rb
+++ b/spec/mysql_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "shared/order_as_specified_examples"
+require "config/test_setup_migration"
+
+RSpec.describe "MySQL" do
+  before :all do
+    ActiveRecord::Base.establish_connection(:mysql_test)
+    TestSetupMigration.migrate(:up)
+  end
+
+  after(:all) { ActiveRecord::Base.remove_connection }
+
+  include_examples ".order_as_specified"
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
-if ENV["TRAVIS"] == "true"
+if ENV["TRAVIS"] == "true" && ENV["CODE_COVERAGE"] == "true"
   require "simplecov"
-  SimpleCov.start
+  require "codecov"
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
   SimpleCov.start do
     # Omit the spec directory from being counted in code coverage calculations.
     add_filter "/spec/"


### PR DESCRIPTION
This commit:

- adds tests for MySQL support
- transfers our Travis CI setup from the deprecated
  travis-ci.org to travis-ci.com
- changes our test setup so tests run on all PRs and
  on changes to the `master` branch
- updates tests to use the latest Ruby version
- changes RuboCop and code coverage to only run on
  one instance of tests
- removes unnecessary rubocop dependencies
- replaces Code Climate, which wasn't fully working,
  with Codecov