### PR TITLE
Fix exclusive range arel usage

### DIFF
--- a/lib/order_as_specified.rb
+++ b/lib/order_as_specified.rb
@@ -30,7 +30,7 @@ module OrderAsSpecified
             raise OrderAsSpecified::Error, "Range needs to be increasing"
           end
 
-          attribute.in(value)
+          attribute.between(value)
         elsif case_insensitive
           attribute.matches(value)
         else


### PR DESCRIPTION
With newer versions of arel, the `in` method enumerates the range and
checks if the value is in that enumeration. The behavior we want is to
find out if the values are within the range, regardless of whether or
not they are enumerated. We use `#between` to get this behavior.